### PR TITLE
Add option to show branch in salck message

### DIFF
--- a/src/commands/approval.yml
+++ b/src/commands/approval.yml
@@ -33,6 +33,12 @@ parameters:
     description: >
       Whether or not to include the Job Number field in the message
 
+  include_job_branch_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Job branch field in the message    
+
   url:
     description: The URL to link back to.
     type: string
@@ -108,6 +114,13 @@ steps:
                       \"short\": true \
                     } \
                     <</ parameters.include_job_number_field >>
+                    <<# parameters.include_job_branch_field >>
+                    { \
+                      \"title\": \"Job Branch\", \
+                      \"value\": \"$CIRCLE_BRANCH\", \
+                      \"short\": true \
+                    } \
+                    <</ parameters.include_job_branch_field >>                    
                   ], \
                   \"actions\": [ \
                     { \

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -61,6 +61,12 @@ parameters:
     type: boolean
     default: true
 
+  include_job_branch_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Job branch field in the message        
+
   include_visit_job_action:
     description: Whether or not to include the Visit Job action in the message
     type: boolean
@@ -143,6 +149,13 @@ steps:
                       \"short\": true \
                     } \
                     <</ parameters.include_job_number_field >>
+                    <<# parameters.include_job_branch_field >>
+                    { \
+                      \"title\": \"Job Branch\", \
+                      \"value\": \"$CIRCLE_BRANCH\", \
+                      \"short\": true \
+                    } \
+                    <</ parameters.include_job_branch_field >>                     
                   ], \
                   \"actions\": [ \
                     <<# parameters.include_visit_job_action >>

--- a/src/commands/status.yml
+++ b/src/commands/status.yml
@@ -50,6 +50,12 @@ parameters:
     default: true
     description: >
       Whether or not to include the Job Number field in the message
+  
+  include_job_branch_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Job branch field in the message      
 
   include_visit_job_action:
     type: boolean
@@ -156,6 +162,13 @@ steps:
                                     \"short\": true \
                                   } \
                                   <</ parameters.include_job_number_field >>
+                                  <<# parameters.include_job_branch_field >>
+                                  { \
+                                    \"title\": \"Job Branch\", \
+                                    \"value\": \"$CIRCLE_BRANCH\", \
+                                    \"short\": true \
+                                  } \
+                                  <</ parameters.include_job_branch_field >>                                  
                                 ], \
                                 \"actions\": [ \
                                   <<# parameters.include_visit_job_action >>
@@ -198,6 +211,13 @@ steps:
                           \"short\": true \
                         } \
                         <</ parameters.include_job_number_field >>
+                        <<# parameters.include_job_branch_field >>
+                        { \
+                          \"title\": \"Job Branch\", \
+                          \"value\": \"$CIRCLE_BRANCH\", \
+                          \"short\": true \
+                        } \
+                        <</ parameters.include_job_branch_field >>                                        
                       ], \
                       \"actions\": [ \
                         <<# parameters.include_visit_job_action >>

--- a/src/jobs/approval-notification.yml
+++ b/src/jobs/approval-notification.yml
@@ -33,6 +33,12 @@ parameters:
     description: >
       Whether or not to include the Job Number field in the message
 
+  include_job_branch_field:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to include the Job branch field in the message   
+
   url:
     description: The URL to link back to.
     type: string

--- a/src/jobs/approval-notification.yml
+++ b/src/jobs/approval-notification.yml
@@ -54,5 +54,6 @@ steps:
       mentions: << parameters.mentions >>
       include_project_field: << parameters.include_project_field >>
       include_job_number_field: << parameters.include_job_number_field >>
+      include_job_branch_field: << parameters.include_job_branch_field >>
       url: << parameters.url >>
       channel: << parameters.channel >>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues


Show the branch in which the job has been  failed or successful is helpful if you have the same jobs across different branchs


### Description


Just add the **job_branch_field** as parameter and  print it as part of the slack message in the curl command in the different **commands** files

